### PR TITLE
Added support for x-shader mime types

### DIFF
--- a/src/shader-art.ts
+++ b/src/shader-art.ts
@@ -72,12 +72,12 @@ export class ShaderArt extends HTMLElement {
   }
 
   get fragCode(): string {
-    const fragScript = this.querySelector('[type="text/frag"], [type=frag]');
+    const fragScript = this.querySelector('[type="x-shader/x-fragment"], [type="text/frag"], [type=frag]');
     return (fragScript?.textContent || DEFAULT_FRAG).trim();
   }
 
   get vertCode(): string {
-    const vertScript = this.querySelector('[type="text/vert"], [type=vert]');
+    const vertScript = this.querySelector('[type="x-shader/x-vertex"], [type="text/vert"], [type=vert]');
     return (vertScript?.textContent || DEFAULT_VERT).trim();
   }
 


### PR DESCRIPTION
Added support for de-facto standard glsl mime types. 

Sources:
https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/Basic_2D_animation_example
https://github.com/racz16/WebGL-GLSL-Editor